### PR TITLE
close files + smaller executable

### DIFF
--- a/fnc.cpp
+++ b/fnc.cpp
@@ -7,12 +7,12 @@ int main(int argc, char **argv){
 	
 	// Creates output for getline()
 	std::string outputStr;
-	
+	std::fstream file;
 	// For loop to open files in order
 	for(int i = 1; i <= argc; i++){ 
 
 		// Opens a file
-		std::fstream file(argv[i]);
+		file = std::fstream(argv[i]);
 	
 		// While loop that checks if the file has ended and if a file has been opened
 		while(!file.eof()&&file.is_open()){
@@ -23,6 +23,8 @@ int main(int argc, char **argv){
 			// Prints outputStr
 			std::cout << outputStr << std::endl;
 		}
+
+		file.close();
 	};
 	
 	return 0;

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 fnc:
-	g++ -o fnc ./fnc.cpp
+	g++ -fno-rtti -fno-exceptions -s -Os -o fnc ./fnc.cpp
 install:
 	cp fnc /bin/fnc
 clean:


### PR DESCRIPTION
- fix: close file after we printed it
- add some compilers flags to make the executable smaller 
	- previously: 17 824b 
	- with -Os: 17 600 
	- with -s: 14 600
	- with -fno-rtti -fno-exceptions: 14 498
